### PR TITLE
changelog type is optional

### DIFF
--- a/readme/changelog.go
+++ b/readme/changelog.go
@@ -88,7 +88,7 @@ type ChangelogParams struct {
 // validChangelogType validates the 'type' field when creating or updating a changelog.
 func validChangelogType(changelogType string) bool {
 	switch changelogType {
-	case "added", "fixed", "improved", "deprecated", "removed":
+	case "", "added", "fixed", "improved", "deprecated", "removed":
 		return true
 	}
 
@@ -144,7 +144,7 @@ func (c ChangelogClient) Create(params ChangelogParams) (Changelog, *APIResponse
 		return Changelog{}, nil, fmt.Errorf("title must be provided")
 	}
 	if !validChangelogType(params.Type) {
-		return Changelog{}, nil, fmt.Errorf("type must be added, fixed, improved, deprecated, or removed")
+		return Changelog{}, nil, fmt.Errorf("type must be added, fixed, improved, deprecated, removed, or left unspecified")
 	}
 
 	payload, err := json.Marshal(params)
@@ -174,7 +174,7 @@ func (c ChangelogClient) Update(slug string, params ChangelogParams) (Changelog,
 		return Changelog{}, nil, fmt.Errorf("title must be provided")
 	}
 	if !validChangelogType(params.Type) {
-		return Changelog{}, nil, fmt.Errorf("type must be added, fixed, improved, deprecated, or removed")
+		return Changelog{}, nil, fmt.Errorf("type must be added, fixed, improved, deprecated, removed, or left unspecified")
 	}
 
 	payload, err := json.Marshal(params)

--- a/readme/changelog_test.go
+++ b/readme/changelog_test.go
@@ -97,7 +97,7 @@ func Test_Changelog_Create(t *testing.T) {
 
 		// Assert
 		assert.ErrorContains(t, err,
-			"type must be added, fixed, improved, deprecated, or removed",
+			"type must be added, fixed, improved, deprecated, removed, or left unspecified",
 			"it returns the expected error",
 		)
 		assert.True(t, gock.IsDone(), "it makes the expected API call")
@@ -155,7 +155,7 @@ func Test_Changelog_Update(t *testing.T) {
 
 		// Assert
 		assert.ErrorContains(t, err,
-			"type must be added, fixed, improved, deprecated, or removed",
+			"type must be added, fixed, improved, deprecated, removed, or left unspecified",
 			"it returns the expected error",
 		)
 	})

--- a/readme/changelog_test.go
+++ b/readme/changelog_test.go
@@ -159,6 +159,26 @@ func Test_Changelog_Update(t *testing.T) {
 			"it returns the expected error",
 		)
 	})
+
+	t.Run("when called with no type", func(t *testing.T) {
+		// Arrange
+		expect := testdata.Changelogs[0]
+		gock.New(TestClient.APIURL).
+			Put(readme.ChangelogEndpoint + "/" + expect.Slug).
+			Reply(200).
+			JSON(testdata.Changelogs[0])
+		defer gock.Off()
+
+		// Act
+		_, _, err := TestClient.Changelog.Update("some-test", readme.ChangelogParams{
+			Title:  testdata.Changelogs[0].Title,
+			Body:   testdata.Changelogs[0].Body,
+			Hidden: &testdata.Changelogs[0].Hidden,
+		})
+
+		// Assert
+		assert.NoError(t, err, "it does not return an error")
+	})
 }
 
 func Test_Changelog_Delete(t *testing.T) {


### PR DESCRIPTION
This makes the `type` field on changelogs optional, as it is in the API.