### PR TITLE
Improve API error responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/liveoaklabs/readme-api-go-client
 
-go 1.21
-toolchain go1.22.4
+go 1.22
+toolchain go1.22.5
 
 require (
 	github.com/boumenot/gocover-cobertura v1.2.0

--- a/readme/api_registry_test.go
+++ b/readme/api_registry_test.go
@@ -42,7 +42,7 @@ func Test_APIRegistry_Get(t *testing.T) {
 		got, gotResponse, err := TestClient.APIRegistry.Get("invalid")
 
 		// Assert
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 404",
+		assert.ErrorContains(t, err, "ReadMe API Error: 404 on GET",
 			"it returns the expected error")
 		assert.Equal(t, string(expect.Body), got,
 			"it returns the expected body")
@@ -109,7 +109,7 @@ func Test_APIRegistry_Create(t *testing.T) {
 		// Assert
 		assert.Equal(t, "ERROR_SPEC_INVALID", apiResponse.APIErrorResponse.Error,
 			"it returns the API error")
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 400",
+		assert.ErrorContains(t, err, "ReadMe API Error: 400 on POST",
 			"it returns expected application error")
 		assert.True(t, gock.IsDone(), "it makes the expected API call")
 	})

--- a/readme/api_specification_test.go
+++ b/readme/api_specification_test.go
@@ -76,7 +76,7 @@ func Test_APISpecification_GetAll(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err, "it returns an error")
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 400",
+		assert.ErrorContains(t, err, "ReadMe API Error: 400 on GET",
 			"it returns expected error")
 		assert.True(t, gock.IsDone(), "it asserts that all mocks were called")
 	})
@@ -386,7 +386,7 @@ func Test_APISpecification_Create(t *testing.T) {
 			JSON(testdata.APISpecResponseSpecFileEmpty.APIErrorResponse)
 
 		expect := "SPEC_FILE_EMPTY"
-		expectErr := "API responded with a non-OK status: 400"
+		expectErr := "ReadMe API Error: 400 on POST"
 
 		// Act
 		_, got, err := TestClient.APISpecification.Create("")
@@ -449,7 +449,7 @@ func Test_APISpecification_Delete(t *testing.T) {
 			JSON(expect)
 		defer gock.Off()
 
-		expectErr := "API responded with a non-OK status: 400"
+		expectErr := "ReadMe API Error: 400 on DELETE"
 
 		// Act
 		got, gotResponse, err := TestClient.APISpecification.Delete("0123456789")

--- a/readme/apply_test.go
+++ b/readme/apply_test.go
@@ -50,7 +50,7 @@ func Test_Apply_Apply(t *testing.T) {
 	t.Run("when called with invalid params", func(t *testing.T) {
 		// Arrange
 		expectResponse := testdata.ApplyCreateResponseInvalidName
-		expectError := errors.New("API responded with a non-OK status: 400")
+		expectError := errors.New("ReadMe API Error: 400 on POST")
 
 		gock.New("http://readme-test.local/api/v1").
 			Post(readme.ApplyEndpoint).
@@ -67,7 +67,7 @@ func Test_Apply_Apply(t *testing.T) {
 		_, got, err := TestClient.Apply.Apply(application)
 
 		// Assert
-		assert.Equal(t, expectError, err, "it returns the expected error")
+		assert.ErrorContains(t, err, expectError.Error(), "it returns expected error")
 		assert.Equal(t, expectResponse.APIErrorResponse,
 			got.APIErrorResponse, "it returns the expected API error response")
 		assert.True(t, gock.IsDone(), "it asserts that all mocks were called")

--- a/readme/category_test.go
+++ b/readme/category_test.go
@@ -254,7 +254,7 @@ func Test_Category_Delete(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err, "it returns an error")
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 400", "it returns the expected error")
+		assert.ErrorContains(t, err, "ReadMe API Error: 400 on DELETE", "it returns the expected error")
 		assert.False(t, got, "it returns false")
 		assert.True(t, gock.IsDone(), "it makes the expected API call")
 	})

--- a/readme/changelog_test.go
+++ b/readme/changelog_test.go
@@ -210,7 +210,7 @@ func Test_Changelog_Delete(t *testing.T) {
 		got, _, err := TestClient.Changelog.Delete("some-test")
 
 		// Assert
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 404", "it returns the expected error")
+		assert.ErrorContains(t, err, "ReadMe API Error: 404 on DELETE", "it returns the expected error")
 		assert.False(t, got, "it returns false")
 		assert.True(t, gock.IsDone(), "it makes the expected API call")
 	})

--- a/readme/custom_page_test.go
+++ b/readme/custom_page_test.go
@@ -188,7 +188,7 @@ func Test_CustomPages_Delete(t *testing.T) {
 		got, _, err := TestClient.CustomPage.Delete("foo")
 
 		// Assert
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 400",
+		assert.ErrorContains(t, err, "ReadMe API Error: 400 on DELETE",
 			"it return the expected error")
 		assert.False(t, got, "it returns false")
 		assert.True(t, gock.IsDone(), "it makes the expected API call")

--- a/readme/doc_test.go
+++ b/readme/doc_test.go
@@ -213,7 +213,7 @@ func Test_Doc_Delete(t *testing.T) {
 		defer gock.Off()
 
 		reqOpts := readme.RequestOptions{Version: "1.1.0"}
-		expectErr := "API responded with a non-OK status: 400"
+		expectErr := "ReadMe API Error: 400 on DELETE"
 
 		// Act
 		got, _, err := TestClient.Doc.Delete("some-test-doc", reqOpts)
@@ -277,7 +277,7 @@ func Test_Doc_Search(t *testing.T) {
 			JSON(expect)
 		defer gock.Off()
 
-		expectErr := "API responded with a non-OK status: 400"
+		expectErr := "ReadMe API Error: 400 on POST"
 
 		// Act
 		_, _, err := TestClient.Doc.Search("something")

--- a/readme/project_test.go
+++ b/readme/project_test.go
@@ -41,7 +41,7 @@ func Test_Project_Get(t *testing.T) {
 		_, got, err := TestClient.Project.Get()
 
 		// Assert
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 401",
+		assert.ErrorContains(t, err, "ReadMe API Error: 401 on GET",
 			"it returns the expected error")
 		assert.Equal(t, expect, got.APIErrorResponse,
 			"it returns the API error response")

--- a/readme/readme.go
+++ b/readme/readme.go
@@ -200,7 +200,7 @@ func (c *Client) APIRequest(request *APIRequest) (*APIResponse, error) {
 	}
 
 	// Verify the HTTP response from the API.
-	apiErrorResponse, err := checkResponseStatus(body, httpResponse.StatusCode, request.OkStatusCode)
+	apiErrorResponse, err := checkResponseStatus(body, httpResponse.StatusCode, request)
 	if err != nil {
 		apiResponse.APIErrorResponse = apiErrorResponse
 
@@ -257,9 +257,9 @@ func (c *Client) doRequest(request *APIRequest) ([]byte, http.Response, error) {
 //
 // If the response code matches a provided code listed in okCodes, no error is returned.
 // If the response code doesn't match, an error and APIErrorResponse is returned.
-func checkResponseStatus(body []byte, responseCode int, okCodes []int) (APIErrorResponse, error) {
+func checkResponseStatus(body []byte, responseCode int, req *APIRequest) (APIErrorResponse, error) {
 	var apiErrorResponse APIErrorResponse
-	for _, okCode := range okCodes {
+	for _, okCode := range req.OkStatusCode {
 		if responseCode == okCode {
 			return apiErrorResponse, nil
 		}
@@ -270,7 +270,9 @@ func checkResponseStatus(body []byte, responseCode int, okCodes []int) (APIError
 		return apiErrorResponse, fmt.Errorf("unable to decode API error response: %w", err)
 	}
 
-	return apiErrorResponse, fmt.Errorf("API responded with a non-OK status: %v", responseCode)
+	return apiErrorResponse,
+		fmt.Errorf("ReadMe API Error: %v on %s %s: %s",
+			responseCode, req.Method, req.Endpoint, body)
 }
 
 // prepareRequest prepares an http.Request for the ReadMe API.

--- a/readme/version_test.go
+++ b/readme/version_test.go
@@ -42,7 +42,7 @@ func Test_Version_GetAll(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// Arrange
 			expect := readme.APIErrorResponse{Error: tc.errMsg}
-			expectErr := fmt.Sprintf("API responded with a non-OK status: %v", tc.status)
+			expectErr := fmt.Sprintf("ReadMe API Error: %v on GET", tc.status)
 			gock.New(TestClient.APIURL).
 				Get(readme.VersionEndpoint).
 				Reply(tc.status).
@@ -122,7 +122,7 @@ func Test_Version_Get(t *testing.T) {
 				JSON(expect)
 			defer gock.Off()
 
-			expectErr := fmt.Sprintf("API responded with a non-OK status: %v", tc.status)
+			expectErr := fmt.Sprintf("ReadMe API Error: %v on GET", tc.status)
 
 			// Act
 			_, apiResponse, err := TestClient.Version.Get("99.99.99")
@@ -242,7 +242,7 @@ func Test_Version_Create_and_Update(t *testing.T) {
 			Version: "1.1.x",
 		}
 
-		expect := "API responded with a non-OK status: 404"
+		expect := "ReadMe API Error: 404 on PUT"
 
 		// Act
 		_, _, err := TestClient.Version.Update("1.1.x", updateParams)
@@ -284,7 +284,7 @@ func Test_Version_Delete(t *testing.T) {
 		got, apiErrorResponse, err := TestClient.Version.Delete("1.0.0")
 
 		// Assert
-		assert.ErrorContains(t, err, "API responded with a non-OK status: 400",
+		assert.ErrorContains(t, err, "ReadMe API Error: 400 on DELETE",
 			"it returns the expected error")
 		assert.Equal(t, apiErrorResponse.APIErrorResponse.Error,
 			"VERSION_CANT_REMOVE_STABLE",


### PR DESCRIPTION
Add more detail to the output when the ReadMe API responds with an error. This now includes the method, path, and error response body.